### PR TITLE
Add downlink confirmation bit description

### DIFF
--- a/DeviceComunication/DeviceComunication.md
+++ b/DeviceComunication/DeviceComunication.md
@@ -321,7 +321,7 @@ The following paragraphs describe the part of the message containing data. All o
 
 ### Acknowledging a message from the server
 
-"Reception from server" acknowledgement message is sent by the device whenever configuration or command message is received from the server.
+"Reception from server" acknowledgement message is sent by the device whenever configuration or command message is received from the server and requires acknowledgement.
 This message serves as an acknowledgement. For more information about sending a message from the server, see [here](#receiving-messages-from-the-server).
 
 In the header it is marked with the value 0x01 in the 7th byte (Message type).
@@ -793,7 +793,7 @@ messages to the device. An uplink is any message sent from a device to a server.
 
 Network server must always wait for the device to initiate the communication. Therefore, it is possible that the delivery of a message from the server might take a long time.
 
-If the device successfully receives the message, it sends an acknowledgement to the server.
+If the device successfully receives the message and acknowledgement is required, it sends an acknowledgement to the server.
   The format of the confirmation message is described [here](#message-acknowledgment).
 
 There is no point for the LoRa network to send an acknowledgement messages from the server to the device, even if the device [requests it](#header),
@@ -808,7 +808,7 @@ the device is acknowledging.
 
 #### Implementation of sending messages to devices in LoRa network
 
-We can implement sending messages to devices in the LoRa network in several ways. The simplest way is "marking messages". In this implementation, the server sends the downlink and marks it as "sent". After it receives the first uplink since the downlink was sent, it changes the status of the sent downlink to "will be acknowledged in the next message". The following uplink message should contain acknowledgment. Arrival of acknowledgment means that the downlink message has been successfully delivered.
+We can implement sending messages to devices in the LoRa network in several ways. The simplest way is "marking messages". In this implementation, the server sends the downlink and marks it as "sent". After it receives the first uplink since the downlink was sent, it changes the status of the sent downlink to "will be acknowledged in the next message". The following uplink message should contain acknowledgment (if requested). Arrival of acknowledgment means that the downlink message has been successfully delivered.
 
 ![LoraMessageMarker](Lora_MessageMarker.png)
 
@@ -837,9 +837,16 @@ is not needed.
 
 Unused.
 
-#### 2nd byte
+#### 2nd byte - parameters
 
-Unused.
+This byte contains a bit mask that currently contains only the downlink message acknowledgement settings. Byte structure:
+
+| Position   | Description                              |
+|------------|------------------------------------------|
+| 0th byte   | Request for acknowledgement of message reception by the device |
+| 0-7th byte | Not used - always 0x00                   |
+
+If the 0th is set to 1 the device sends an receipt acknowledgement of the current message.
 
 #### 3rd byte
 

--- a/DeviceComunication/DeviceComunication.md
+++ b/DeviceComunication/DeviceComunication.md
@@ -839,12 +839,12 @@ Unused.
 
 #### 2nd byte - parameters
 
-This byte contains a bit mask that currently contains only the downlink message acknowledgement settings. Byte structure:
+This byte contains a bit mask that currently contains only the downlink message acknowledgement settings. The bit at position 0 determines whether the message should be acknowledged (1 - acknowledgement required; 0 - no acknowledgement). Byte structure:
 
 | Position   | Description                              |
 |------------|------------------------------------------|
-| 0th byte   | Request for acknowledgement of message reception by the device |
-| 0-7th byte | Not used - always 0x00                   |
+| 0th bit    | Request for acknowledgement of message reception by the device |
+| 0-7th bit  | Not used - always 0x00                   |
 
 If the 0th is set to 1 the device sends an receipt acknowledgement of the current message.
 
@@ -1154,7 +1154,7 @@ Following commands are defined:
 | 0x02  | Adaptation              | Starts the adaptation procedure. |
 | 0x03  | Rotation                | Starts the rotation procedure. (Similar to adaptation, but the valve returns to the original position) |
 | 0x04  | Set disconnect position | Sets position the device transitions to in case of communication severance. |
-| 0x05  | Set motor power         | Sets the motor power. The required position is passed via `Parameter` and ranges from 0 to 100%. Default value is 50% |
+| 0x05  | Set motor power         | Sets the motor power. The required position is passed via `Parameter` and ranges from 0 to 100%. Default value is 50%. It is not recommended to change this parameter. |
 | 0xFF  | Unadaptation            | Restores the device to state before adaptation. |
 
 

--- a/DeviceComunication/DeviceComunication_CZ.md
+++ b/DeviceComunication/DeviceComunication_CZ.md
@@ -336,7 +336,7 @@ hlavičkou která je [popsaná výše](#hlavička).
 
 ### Potvrzení zprávy ze serveru
 
-Potvrzení zprávy ze serveru zařízení odešle vždy po přijetí konfigurace nebo příkazu ze serveru.
+Potvrzení zprávy ze serveru zařízení odešle vždy po přijetí konfigurace nebo příkazu ze serveru, který vyžaduje potvrzení.
 Tato zpráva slouží jako potvrzení. Více o odesílání zprávy ze serveru najdete [zde](#přijmání-zpráv-ze-serveru).
 
 V hlavičce je označen hodnotou 0x01 v 7.bytu (Typ zprávy).
@@ -829,7 +829,7 @@ zprávy na zařízení. Uplink je jakákoliv zpráva odesílaná ze zařízení 
 Network server vždy musí čekat na zahájení komunikace ze zařízení. Může se tudíž
 stát, že zpráva ze serveru je doručena po dlouhé době.
 
-Pokud zařízení úspěšně přijme zprávu, odešle na server
+Pokud zařízení úspěšně přijme zprávu a je požadováno potvrzení, odešle na server
 potvrzení. Formát potvrzovací zprávy je popsán [zde](#potvrzení-zprávy).
 
 Potvrzovací zprávy ze serveru na zařízení nemá u LoRa síťě význam odesílat, ikdyž si ji zařízení [vyžádá](#hlavička), jelikož o potvrzení se stará LoRa síť automaticky (u zpráv vyžadujících potvrzení).
@@ -849,7 +849,7 @@ zařízení potvrzuje.
 Implementaci odesílání zpráv na zařízení v LoRa síti můžeme provést
 několika způsoby. Nejjednoduším způsobem je "označování zpráv". V této
 implementaci server odešle downlink a označí ho jako
-"odeslaný". Poté, co přijme první uplink od odeslání downlinku, stav odeslaného downlinku změní na "bude potvrzen v příští zprávě". V další zprávě by měl přijít uplink s potvrzením. Pokud toto potvrzení dorazí, downlinková zpráva byla úspěšně odeslána.
+"odeslaný". Poté, co přijme první uplink od odeslání downlinku, stav odeslaného downlinku změní na "bude potvrzen v příští zprávě". V další zprávě by měl přijít uplink s potvrzením (pokud bylo vyžádáno). Pokud toto potvrzení dorazí, downlinková zpráva byla úspěšně odeslána.
 
 ![LoraMessageMarker](Lora_MessageMarker.png)
 
@@ -884,9 +884,16 @@ není potřeba.
 
 Nepoužitý.
 
-#### 2.byte
+#### 2.byte - parametry
 
-Nepoužitý.
+Tento byte obsahuje bitovou masku, která aktuálně obsahuje pouze nastavení potvrzení downlinkové zprávy. Složení bytu:
+
+| Pozice  | Význam                                      |
+|---------|---------------------------------------------|
+| 0.bit   | Žádost o potvrzení přijetí zprávy zařízením |
+| 1-7.bit | Nepoužité                                   |
+
+Pokud je 0.bit nastaven na 1 tak zařízení odešle potvrzení o přijetí aktuální zprávy.
 
 #### 3.byte
 

--- a/DeviceComunication/DeviceComunication_CZ.md
+++ b/DeviceComunication/DeviceComunication_CZ.md
@@ -886,7 +886,7 @@ Nepoužitý.
 
 #### 2.byte - parametry
 
-Tento byte obsahuje bitovou masku, která aktuálně obsahuje pouze nastavení potvrzení downlinkové zprávy. Složení bytu:
+Tento byte obsahuje bitovou masku, která aktuálně obsahuje pouze nastavení potvrzení downlinkové zprávy. Bit na 0-té pozici určuje, zda má být zpráva potvrzena (1 - vyžadováno potvrzení; 0 - bez potvrzení). Složení bytu:
 
 | Pozice  | Význam                                      |
 |---------|---------------------------------------------|
@@ -1199,7 +1199,7 @@ Jsou definovány tyto příkazy:
 | 0x02  | Adaptace                | Spustí proceduru adaptace. |
 | 0x03  | Protočení               | Spustí proceduru protočení. (Obdoba procedury Adaptace, ale hlavice je po ukončení na původní pozici.) |
 | 0x04  | Nastav disconnect pozici| Nastaví pozici na niž termohlavice přejde v případě přerušení komunikace se serverem. |
-| 0x05  | Nastav příkon motoru    | Nastav příkon motoru. Požadovaný příkon je předán skrz `Parametr` a může nabývat hodnot od 0 do 100%. Základní hodnota je 50% |
+| 0x05  | Nastav příkon motoru    | Nastav příkon motoru. Požadovaný příkon je předán skrz `Parametr` a může nabývat hodnot od 0 do 100%. Základní hodnota je 50%. Není doporučeno tento parametr měnit. |
 | 0xFF  | Odadaptace              | Vrátí zařízení do původního nastavení. |
 
 ## Zjednodušená implementace potvrzování


### PR DESCRIPTION
Schémátka ponechána původní, ukazují variantu s potvrzováním, což je 99% případů. To že potvrzování tam být nemusí je zmíněno jen v textu.